### PR TITLE
nss-dp: fix hardware STP state sync with the kernel

### DIFF
--- a/include/nss_dp_dev.h
+++ b/include/nss_dp_dev.h
@@ -357,6 +357,7 @@ void nss_dp_switchdev_setup(struct net_device *dev);
 void nss_dp_switchdev_cleanup(struct net_device *dev);
 bool nss_dp_is_phy_dev(struct net_device *dev);
 #endif
+extern struct notifier_block nss_dp_netdev_notifier;
 
 /*
  * nss_dp_get_idx_from_macid()

--- a/nss_dp_main.c
+++ b/nss_dp_main.c
@@ -1256,6 +1256,9 @@ static int __init nss_dp_init(void)
 	ret = platform_driver_register(&nss_dp_drv);
 	if (ret)
 		pr_info("NSS DP platform drv register failed\n");
+	ret = register_netdevice_notifier(&nss_dp_netdev_notifier);
+	if (ret)
+		pr_warn("netdevice notifier register failed: ret=%d\n", ret);
 
 	dp_global_ctx.common_init_done = true;
 	pr_info("**********************************************************\n");
@@ -1274,6 +1277,7 @@ static void __exit nss_dp_exit(void)
 	 * Ensure netdev remove is done before HAL cleanup.
 	 */
 	platform_driver_unregister(&nss_dp_drv);
+	unregister_netdevice_notifier(&nss_dp_netdev_notifier);
 
 	if (dp_global_ctx.common_init_done) {
 		nss_dp_hal_cleanup();

--- a/nss_dp_switchdev.c
+++ b/nss_dp_switchdev.c
@@ -20,6 +20,7 @@
 
 #include <linux/if_bridge.h>
 #include <linux/if_vlan.h>
+#include <linux/netdevice.h>
 #include <linux/version.h>
 #include <net/switchdev.h>
 #ifdef NSS_DP_SW_BR_OPS
@@ -34,14 +35,106 @@
 #include "ref/ref_vsi.h"
 #endif
 
+static bool switch_init_done;
+
+static inline bool nss_dp_supports_fal_stp_ops(void)
+{
+#ifdef NSS_DP_IPQ50XX
+	return false;
+#else
+	return true;
+#endif
+}
+
 #define NSS_DP_SWITCH_ID		0
 #define NSS_DP_SW_ETHTYPE_PID		0 /* PPE ethtype profile ID for slow protocols */
 #define ETH_P_NONE			0
 
 static int nss_dp_bridge_attr_set(struct net_device *dev,
 				const struct switchdev_attr *attr);
+/*
+ * nss_dp_netdev_event()
+ *	Netdevice event handler to fix STP state for NSS data plane ports.
+ */
+static int nss_dp_stp_state_set(struct nss_dp_dev *dp_priv, u8 state);
 
-static bool switch_init_done;
+static int nss_dp_stp_state_set(struct nss_dp_dev *dp_priv, u8 state);
+
+static int nss_dp_netdev_event(struct notifier_block *unused,
+			       unsigned long event, void *ptr)
+{
+	struct netdev_notifier_changeupper_info *info = ptr;
+	struct net_device *dev = netdev_notifier_info_to_dev(ptr);
+	struct net_device *master = NULL;
+	struct nss_dp_dev *dp_priv;
+	sw_error_t err;
+	fal_stp_state_t stp_state;
+
+	if (event != NETDEV_CHANGEUPPER)
+		return NOTIFY_DONE;
+
+	if (!dev) {
+		pr_warn("netdev notifier without dev\n");
+		return NOTIFY_DONE;
+	}
+
+	rcu_read_lock();
+	master = netdev_master_upper_dev_get_rcu(dev);
+	if (master)
+		dev_hold(master);
+	rcu_read_unlock();
+
+	netdev_dbg(dev, "netdev event=%lu linking=%d master=%s\n",
+		    event, info ? info->linking : -1,
+		    master ? master->name : "nomaster");
+
+	if (master)
+		dev_put(master);
+
+	if (info && info->linking)
+		return NOTIFY_DONE;
+
+	if (!nss_dp_is_phy_dev(dev))
+		return NOTIFY_DONE;
+
+	dp_priv = netdev_priv(dev);
+	if (!dp_priv)
+		return NOTIFY_DONE;
+
+	if (!nss_dp_supports_fal_stp_ops())
+		return NOTIFY_DONE;
+
+	err = fal_stp_port_state_get(NSS_DP_SWITCH_ID, 0, dp_priv->macid, &stp_state);
+	if (!err)
+		netdev_dbg(dev, "current fal stp state=%d\n", stp_state);
+	else
+		netdev_dbg(dev, "failed to get fal stp state err=%d %pe\n", err, ERR_PTR(err));
+
+	netdev_dbg(dev, "master removed -> forcing forwarding fal stp state=%d FAL_STP_FORWARDING\n", FAL_STP_FORWARDING);
+	nss_dp_stp_state_set(dp_priv, BR_STATE_FORWARDING);
+
+	return NOTIFY_DONE;
+}
+
+/*
+ * nss_dp_is_bridge_port()
+ *	Returns true if port is currently enslaved to a bridge/master.
+ */
+static bool nss_dp_is_bridge_port(struct net_device *dev)
+{
+	struct net_device *br_dev;
+
+	rcu_read_lock();
+	br_dev = netdev_master_upper_dev_get_rcu(dev);
+	rcu_read_unlock();
+
+	bool is_bridge = br_dev != NULL;
+
+	if (!is_bridge)
+		netdev_dbg(dev, "device=%s no longer enslaved to bridge\n", dev->name);
+
+	return is_bridge;
+}
 
 /*
  * nss_dp_set_slow_proto_filter()
@@ -52,6 +145,9 @@ static void nss_dp_set_slow_proto_filter(struct nss_dp_dev *dp_priv, bool filter
 	sw_error_t ret = 0;
 	fal_ctrlpkt_profile_t profile;
 	fal_ctrlpkt_action_t action;
+
+	if (!nss_dp_supports_fal_stp_ops())
+		return;
 
 	memset(&profile, 0, sizeof(profile));
 
@@ -135,6 +231,11 @@ static int nss_dp_stp_state_set(struct nss_dp_dev *dp_priv, u8 state)
 {
 	sw_error_t err;
 	fal_stp_state_t stp_state;
+
+	if (!nss_dp_supports_fal_stp_ops())
+		return 0;
+
+	netdev_dbg(dp_priv->netdev, "setting STP state=%u\n", state);
 
 	switch (state) {
 	case BR_STATE_DISABLED:
@@ -236,6 +337,12 @@ static int nss_dp_attr_set(struct net_device *dev,
 		netdev_dbg(dev, "set brport_flags %lu\n", attr->u.brport_flags);
 		return 0;
 	case SWITCHDEV_ATTR_ID_PORT_STP_STATE:
+		if (!nss_dp_is_bridge_port(dev)) {
+			netdev_dbg(dev, "Skip STP state %u: not a bridge port\n",
+				    stp_state);
+			return 0;
+		}
+
 		/*
 		 * The stp state is not changed to FAL_STP_DISABLED if
 		 * the net_device (dev) has any vlan configured. Otherwise
@@ -314,6 +421,11 @@ static int nss_dp_port_attr_set(struct net_device *dev,
 	case SWITCHDEV_ATTR_ID_BRIDGE_AGEING_TIME:
 		return nss_dp_bridge_attr_set(dev, attr);
 	case SWITCHDEV_ATTR_ID_PORT_STP_STATE:
+		if (!nss_dp_is_bridge_port(dev)) {
+			netdev_dbg(dev, "Skip STP state %u: not a bridge port\n",
+				    attr->u.stp_state);
+			return 0;
+		}
 		return nss_dp_stp_state_set(dp_priv, attr->u.stp_state);
 	default:
 		return -EOPNOTSUPP;
@@ -367,6 +479,10 @@ static int nss_dp_switchdev_event(struct notifier_block *unused,
 
 static struct notifier_block nss_dp_switchdev_notifier = {
 	.notifier_call = nss_dp_switchdev_event,
+};
+
+struct notifier_block nss_dp_netdev_notifier = {
+	.notifier_call = nss_dp_netdev_event,
 };
 
 #ifdef NSS_DP_SW_BR_OPS
@@ -640,7 +756,7 @@ void nss_dp_switchdev_cleanup(struct net_device *dev)
 	if (nss_dp_sw_ev_nb) {
 		unregister_switchdev_notifier(nss_dp_sw_ev_nb);
 	}
-        switch_init_done = false;
+	switch_init_done = false;
 }
 
 /*


### PR DESCRIPTION
Issue: every up interface starts in FAL_STP_FORWARDING, but when a bridge removes the port it drops into FAL_STP_DISABLED and stays there until the switch is rebooted or the port is enslaved again, even though the kernel already treats the interface as plain UP. As a result no traffic gets forwarded after the bridge detach.

Fix:
- register a netdev notifier and, on NETDEV_CHANGEUPPER, force the port back into BR_STATE_FORWARDING/FAL_STP_FORWARDING when the master disappears
- before applying SWITCHDEV_ATTR_ID_PORT_STP_STATE ensure the interface is still enslaved and translate each BR_STATE_* into the matching FAL_STP_* with explicit logging


tested on: 
yuncore,ax880 (ipq8072)
yuncore,fap650 (ipq6018)


```
root@ru-ax880:~# ip l set wan nomaster
[  202.470897] br-lan: port 11(wan) entered disabled state
[  202.471186] nss-dp 3a003000.dp5-syn wan: setting STP state=0
[  202.475225] nss-dp 3a003000.dp5-syn wan: netdev event 22 linking=0 master=nomaster
[  202.480889] nss-dp 3a003000.dp5-syn wan: upper removed -> forcing forwarding
[  202.488232] nss-dp 3a003000.dp5-syn wan: setting STP state=3
root@ru-ax880:~# udhcpc -i wan
udhcpc: started, v1.35.0
udhcpc: broadcasting discover
udhcpc: broadcasting select for 10.11.11.105, server 10.11.11.2
udhcpc: lease of 10.11.11.105 obtained from 10.11.11.2, lease time 43200
udhcpc: ip addr add 10.11.11.105/255.255.255.0 broadcast 10.11.11.255 dev wan
udhcpc: setting default routers: 10.11.11.2
root@ru-ax880:~# ping 1.1.1.1 -c 1 >/dev/null 2>&1 && echo ok
ok
root@ru-ax880:~# ip l set wan master br-lan
[  227.370877] br-lan: port 11(wan) entered blocking state
[  227.370925] br-lan: port 11(wan) entered disabled state
[  227.375254] nss-dp 3a003000.dp5-syn wan: netdev event 22 linking=1 master=br-lan
[  227.380314] br-lan: port 11(wan) entered blocking state
[  227.387797] br-lan: port 11(wan) entered forwarding state
[  227.392901] nss-dp 3a003000.dp5-syn wan: setting STP state=4
[  227.398288] nss-dp 3a003000.dp5-syn wan: setting STP state=0
[  227.404070] nss-dp 3a003000.dp5-syn wan: setting STP state=4
[  227.409649] nss-dp 3a003000.dp5-syn wan: setting STP state=3
root@ru-ax880:~# ping 1.1.1.1 -c 1 >/dev/null 2>&1 && echo ok
ok
root@ru-ax880:~#
```
