### PR TITLE
qca-nss-dp: update to win.nss.1.1 2026-01-12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,14 +108,16 @@ ccflags-y += -DNSS_DP_IPQ95XX
 endif
 
 ifeq ($(SoC),$(filter $(SoC),ipq54xx))
+ccflags-y += -DNSS_DP_IPQ54XX
 ccflags-y += -DNSS_DP_EDMA_SKIP_PL_OFFSET
-ccflags-y += -DNSS_DP_EDMA_REG_WORD_INDEXING
+ccflags-y += -DNSS_DP_HIGHER_RING_MASK_CONFIG
+ccflags-y += -DNSS_DP_MDIO_HIGHER_VP_PORTS_SUPP
+ccflags-y += -DNSS_DP_HIGHER_FC_CONFIG
+ccflags-y += -DNSS_DP_RING_IDX_CONFIG
 ccflags-y += -DNSS_DP_EDMA_SKIP_FOUR_PPEDS_NODES
 ccflags-y += -DNSS_DP_EDMA_MHT_SW_WITH_VP_RING
-endif
-
-ifeq ($(higher-address-support),y)
-ccflags-y += -DEDMA_40BIT_SUPPORT
+ccflags-y += -DNSS_DP_EDMA_RING_RESET
+ccflags-y += -DNSS_DP_EDMA_LOOPBACK_BUF_CONFIG
 endif
 
 ccflags-y += $(NSS_DP_INCLUDE)

--- a/exports/nss_dp_api_if.h
+++ b/exports/nss_dp_api_if.h
@@ -2,7 +2,7 @@
  **************************************************************************
  * Copyright (c) 2016-2021, The Linux Foundation. All rights reserved.
  *
- * Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
  *
  * Permission to use, copy, modify, and/or distribute this software for
  * any purpose with or without fee is hereby granted, provided that the
@@ -62,6 +62,8 @@
 
 #define MAX_MHT_PORTS	4
 
+#define MAX_ETH_TYPES 2
+
 /**
  * nss_dp_eth_netdev_info
  * 	Structure for retrieving the eth info
@@ -86,6 +88,16 @@ struct nss_dp_data_plane_ctx {
  */
 struct nss_dp_gmac_stats {
 	struct nss_dp_hal_gmac_stats stats;
+};
+
+/**
+ * nss_dp_vlan_append_info
+ *	VLAN append info structure.
+ */
+struct nss_dp_vlan_append_info {
+	bool vlan_en;				/**< Vlan Append Flag */
+	uint16_t ether_types[MAX_ETH_TYPES];	/**< Ethernet Type */
+	uint32_t vlan_tag_info;			/**< VLAN Header Info */
 };
 
 /**

--- a/exports/nss_dp_vp.h
+++ b/exports/nss_dp_vp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) 2022, 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -17,6 +17,9 @@
 #ifndef __NSS_DP_VP_H__
 #define __NSS_DP_VP_H__
 
+#include <linux/bitmap.h>
+#include <ppe_drv_public.h>
+
 /*
  * nss_dp_vp_tx_info
  *	VP Tx info.
@@ -26,6 +29,7 @@ struct nss_dp_vp_tx_info {
 	uint8_t sc;			/**< Service code. */
 	uint8_t svp;			/**< Source VP number. */
 	uint8_t dvp;			/**< Destination VP number. */
+	uint8_t egress_macid;		/**< Egress Port Mac Id. */
 	bool fake_mac;			/**< Needs Fake Mac. */
 };
 
@@ -34,30 +38,40 @@ struct nss_dp_vp_tx_info {
  *	VP info struct struct
  */
 struct nss_dp_vp_rx_info {
+	struct napi_struct *napi;	/* RX NAPI */
+	uint32_t batch_bytes;		/* Total bytes carried by batch of skbs */
+	int32_t flow_idx;		/* Flow index of a packet */
+	uint16_t l3offset;		/* L3 offset of packet */
 	uint8_t dvp;			/* Destination VP number */
 	uint8_t svp;			/* Source VP number */
-	uint16_t l3offset;		/* L3 offset of packet */
 	uint8_t ip_summed;		/* IP checksum */
-	int32_t flow_idx;		/* Flow index of a packet */
-	struct napi_struct *napi;	/* RX NAPI */
+	bool fake_mac;			/* Fake Mac Present */
+	bool qdisc_valid;		/* Qdisc valid */
 };
 
 /*
- * nss_dp_vp_skb_list
- *	skb list of a VP
+ * nss_dp_vp_node_info
+ *	PPE VP node info
  */
-struct nss_dp_vp_skb_list{
-	struct nss_dp_vp_skb_list *next;
-	struct sk_buff_head skb_list;	/* skb list*/
-	uint16_t len;			/* Total data length carried by these skb*/
+struct nss_dp_vp_node_info {
+	uint32_t bytes;			/* Total bytes carried batch of skbs */
 	uint8_t dvp;			/* Destination VP */
+};
+
+/*
+ * nss_dp_vp_node
+ *	Node for VP specific operations(batching)
+ */
+struct nss_dp_vp_node {
+	struct sk_buff_head head;		/* Skb list */
+	struct nss_dp_vp_node_info info;	/* VP node info */
 };
 
 /*
  * nss_dp_vp_list_rx_cb_t
  *	Vp rx handler callback typedef
  */
-typedef void (*nss_dp_vp_list_rx_cb_t)( struct nss_dp_vp_skb_list *vp_rx_list);
+typedef void (*nss_dp_vp_list_rx_cb_t)(struct sk_buff_head *head, struct nss_dp_vp_rx_info *rx_info);
 
 /*
  * nss_dp_vp_rx_cb_t
@@ -65,22 +79,69 @@ typedef void (*nss_dp_vp_list_rx_cb_t)( struct nss_dp_vp_skb_list *vp_rx_list);
  */
 typedef void (*nss_dp_vp_rx_cb_t)(struct sk_buff *skb, struct nss_dp_vp_rx_info *vprxi);
 
+/*
+ * nss_dp_vp_rx_ops
+ *	VP rx operations
+ */
+struct nss_dp_vp_rx_ops {
+	nss_dp_vp_list_rx_cb_t list_cb;
+	nss_dp_vp_rx_cb_t cb;
+	void *app_data;
+};
+
+/*
+ * nss_dp_vp_ctx
+ *	Context per VP node
+ */
+struct nss_dp_vp_ctx {
+	DECLARE_BITMAP(active_vps, PPE_DRV_VIRTUAL_MAX);
+	struct nss_dp_vp_node nodes[PPE_DRV_VIRTUAL_MAX];
+	struct nss_dp_vp_rx_ops ops;
+};
+
 /**
  * nss_dp_vp_rx_register_cb
  *	Register handler for VP rx processing.
  *
  * @datatypes
  * nss_dp_vp_rx_cb_t
- * nss_dp_vp_list_rx_cb_t
  *
  * @param[in] nss_dp_vp_tx_info Pointer to VP rx handler.
- * @param[in] nss_dp_vp_list_rx_cb_t Pointer to VP list handler.
+ *
+ * @return
+ * True or false.
+ *
+ * @note: This API needs to deprecated and replaced with nss_dp_vp_rx_register_ops()
+ */
+bool nss_dp_vp_rx_register_cb(nss_dp_vp_rx_cb_t cb);
+
+/**
+ * nss_dp_vp_rx_register_ops
+ *	Register ops for VP rx processing.
+ *
+ * @datatypes
+ * struct nss_dp_vp_rx_ops
+ *
+ * @param[in] ops Pointer to VP rx ops.
  *
  * @return
  * True or false.
  */
-bool nss_dp_vp_rx_register_cb(nss_dp_vp_rx_cb_t cb, \
-		nss_dp_vp_list_rx_cb_t list_cb);
+void nss_dp_vp_rx_register_ops(struct nss_dp_vp_rx_ops *ops);
+
+/**
+ * nss_dp_vp_rx_unregister_ops
+ *	Unregister ops for VP rx processing.
+ *
+ * @datatypes
+ * None
+ *
+ * @param[in]
+ *
+ * @return
+ * None.
+ */
+void nss_dp_vp_rx_unregister_ops(void);
 
 /**
  * nss_dp_vp_rx_unregister_cb

--- a/hal/include/nss_dp_hal.h
+++ b/hal/include/nss_dp_hal.h
@@ -46,5 +46,7 @@ extern struct nss_dp_data_plane_ops *nss_dp_hal_get_data_plane_ops(void);
 extern bool nss_dp_hal_init(void);
 extern void nss_dp_hal_cleanup(void);
 extern struct nss_dp_ppeds_ops* nss_dp_ppeds_ops_get(void);
+extern void nss_dp_hal_init_soc_priv_flags(struct nss_dp_dev *dp_priv);
+extern void nss_dp_hal_deinit_soc_priv_flags(struct nss_dp_dev *dp_priv);
 
 #endif	/* __NSS_DP_HAL_H__ */

--- a/hal/soc_ops/ipq50xx/nss_ipq50xx.c
+++ b/hal/soc_ops/ipq50xx/nss_ipq50xx.c
@@ -31,6 +31,24 @@ bool nss_dp_hal_nsm_sawf_sc_stats_read(struct nss_dp_hal_nsm_sawf_sc_stats *nsm_
 }
 
 /*
+ * nss_dp_hal_deinit_soc_priv_flags()
+ *	API to de-initialize DP DEV flags field
+ */
+void nss_dp_hal_deinit_soc_priv_flags(struct nss_dp_dev *dp_priv)
+{
+	return;
+}
+
+/*
+ * nss_dp_hal_init_soc_priv_flags()
+ *	API to initialize DP DEV flags field
+ */
+void nss_dp_hal_init_soc_priv_flags(struct nss_dp_dev *dp_priv)
+{
+	return;
+}
+
+/*
  * nss_dp_hal_tcsr_base_get()
  *	Reads TCSR base address from DTS
  */

--- a/hal/soc_ops/ipq50xx/nss_ipq50xx.h
+++ b/hal/soc_ops/ipq50xx/nss_ipq50xx.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020-2021, The Linux Foundation. All rights reserved.
  *
- * Copyright (c) 2021-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) 2021-2024 Qualcomm Innovation Center, Inc. All rights reserved.
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -38,6 +38,7 @@
  */
 #define NSS_DP_HAL_RX_NAPI_BUDGET		32
 #define NSS_DP_HAL_TX_NAPI_BUDGET		32
+#define NSS_DP_HAL_RXFILL_NAPI_BUDGET		0
 
 /*
  * TCSR_GMAC_AXI_CACHE_OVERRIDE register size

--- a/hal/soc_ops/ipq53xx/nss_ipq53xx.c
+++ b/hal/soc_ops/ipq53xx/nss_ipq53xx.c
@@ -40,6 +40,24 @@ struct nss_dp_data_plane_ops *nss_dp_hal_get_data_plane_ops(void)
 }
 
 /*
+ * nss_dp_hal_deinit_soc_priv_flags()
+ *	API to de-initialize DP DEV flags field
+ */
+void nss_dp_hal_deinit_soc_priv_flags(struct nss_dp_dev *dp_priv)
+{
+	return;
+}
+
+/*
+ * nss_dp_hal_init_soc_priv_flags()
+ *	API to initialize DP DEV flags field
+ */
+void nss_dp_hal_init_soc_priv_flags(struct nss_dp_dev *dp_priv)
+{
+	return;
+}
+
+/*
  * nss_dp_hal_clock_set_and_enable()
  *	API to set and enable the EDMA common clocks
  */
@@ -65,6 +83,19 @@ int32_t nss_dp_hal_clock_set_and_enable(struct device *dev, const char *id, unsi
 		return -1;
 	}
 
+	return 0;
+}
+
+/*
+ * nss_dp_hal_cache_info_setup()
+ *	Dummy wrap-around function.
+ *	Returns 0: success
+ */
+int nss_dp_hal_cache_info_setup(void *ctx)
+{
+	struct edma_gbl_ctx *egc = (struct edma_gbl_ctx *)ctx;
+
+	egc->cache_data = NULL;
 	return 0;
 }
 
@@ -207,7 +238,7 @@ int32_t nss_dp_hal_hw_reset(void *ctx)
 	}
 
 	edma_cfg_rst = devm_reset_control_get(&pdev->dev, EDMA_CFG_RESET_ID);
-        if (IS_ERR(edma_hw_rst)) {
+        if (IS_ERR(edma_cfg_rst)) {
                 return -EINVAL;
         }
 
@@ -218,14 +249,14 @@ int32_t nss_dp_hal_hw_reset(void *ctx)
 	 *
 	 * TODO: Revisit if this global storage is actually required.
 	 */
-	edma_gbl_ctx.hw_rst = edma_hw_rst;
+	edma_gbl_ctx->hw_rst = edma_hw_rst;
 
 	/*
          * Store the obtained edma configuration reset handle (`edma_cfg_rst`) in the global context
          * (`edma_gbl_ctx`) for future use. This allows for centralized configuration reset control
          * throughout the driver.
 	 */
-	edma_gbl_ctx.cfg_rst = edma_cfg_rst;
+	edma_gbl_ctx->cfg_rst = edma_cfg_rst;
 
 	reset_control_assert(edma_hw_rst);
 	udelay(100);

--- a/hal/soc_ops/ipq53xx/nss_ipq53xx.h
+++ b/hal/soc_ops/ipq53xx/nss_ipq53xx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -13,6 +13,8 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
+
+#include <asm/cacheflush.h>
 
 #ifndef __NSS_DP_ARCH_H__
 #define __NSS_DP_ARCH_H__
@@ -65,6 +67,7 @@
  */
 #define NSS_DP_HAL_RX_NAPI_BUDGET	128
 #define NSS_DP_HAL_TX_NAPI_BUDGET	256
+#define NSS_DP_HAL_RXFILL_NAPI_BUDGET	512
 
 /*
  * Timestamp information for the latency measurement
@@ -120,6 +123,19 @@
 #define NSS_DP_EDMA_SNOC_NSSNOC_CLK_FREQ		266666666
 #define NSS_DP_EDMA_SNOC_NSSNOC_1_CLK_FREQ		266666666
 
+#define EDMA_MAX_DMA_MASK_BIT_HI 32
+
+/*
+ * SoC specific RX ring max value
+ */
+#if defined (NSS_DP_VP_RINGS)
+#define NSS_DP_VP_NUM_RINGS 1
+#else
+#define NSS_DP_VP_NUM_RINGS 0
+#endif
+
+#define EDMA_RX_DESC_RING_MAX (NR_CPUS + NSS_DP_VP_NUM_RINGS)
+
 /**
  * nss_dp_hal_gmac_stats
  *	The per-GMAC statistics structure.
@@ -162,9 +178,30 @@ extern bool nss_dp_hal_nsm_sawf_sc_stats_read(struct nss_dp_hal_nsm_sawf_sc_stat
 extern int32_t nss_dp_hal_clock_set_and_enable(struct device *dev, const char *id, unsigned long rate);
 extern struct nss_dp_data_plane_ops nss_dp_edma_ops;
 extern int32_t nss_dp_hal_configure_clocks(void *ctx);
+extern int nss_dp_hal_cache_info_setup(void *ctx);
 extern int32_t nss_dp_hal_hw_reset(void *ctx);
 #ifdef NSS_DP_PPEDS_SUPPORT
 extern struct nss_dp_ppeds_ops edma_ppeds_ops;
 #endif
+
+static inline void edma_dmac_inv_range(const void *start, const void *end){
+
+        dmac_inv_range(start, end);
+}
+
+static inline void edma_dmac_inv_range_no_dsb(const void *start, const void *end){
+
+        dmac_inv_range_no_dsb(start, end);
+}
+
+static inline void edma_dmac_clean_range_no_dsb(const void *start, const void *end){
+
+        dmac_clean_range_no_dsb(start, end);
+}
+
+static inline void edma_dsb(void){
+
+        dsb(st);
+}
 
 #endif /* __NSS_DP_ARCH_H__ */

--- a/hal/soc_ops/ipq54xx/nss_ipq54xx.c
+++ b/hal/soc_ops/ipq54xx/nss_ipq54xx.c
@@ -20,6 +20,14 @@
 #include <nss_dp_arch.h>
 #include "nss_dp_hal.h"
 
+#ifdef CONFIG_IO_COHERENCY
+#include "edma_regs.h"
+#include <linux/tmelcom_ipc.h>
+#include <linux/of_platform.h>
+#include <linux/of_address.h>
+#include <linux/platform_device.h>
+#endif
+
 /*
  * nss_dp_hal_nsm_sawf_sc_stats_read()
  *	Send nsm stats for the given service-class.
@@ -37,6 +45,163 @@ struct nss_dp_data_plane_ops *nss_dp_hal_get_data_plane_ops(void)
 {
 	return &nss_dp_edma_ops;
 }
+
+/*
+ * nss_dp_hal_deinit_soc_priv_flags()
+ *	API to de initialize DP DEV flags field
+ */
+void nss_dp_hal_deinit_soc_priv_flags(struct nss_dp_dev *dp_priv)
+{
+	clear_bit(__NSS_DP_NO_LIST, &dp_priv->flags);
+}
+
+/*
+ * nss_dp_hal_init_soc_priv_flags()
+ *	API to initialize DP DEV flags field
+ */
+void nss_dp_hal_init_soc_priv_flags(struct nss_dp_dev *dp_priv)
+{
+	set_bit(__NSS_DP_NO_LIST, &dp_priv->flags);
+}
+
+#ifdef CONFIG_IO_COHERENCY
+
+/*
+ * nss_noc_reg_write - Write the value into NSS NOC registers
+ * @reg_base: base address for the NSS NOC registers
+ * @regs_off: Pointer to the register offset and data to be written into
+ * @count: Number of registers
+ * @secure_write: Indicates secure IO write/Regular IO write
+ *
+ * This function returns 0 on success, and negative error code on failure
+ */
+static inline int nss_noc_reg_write(uint32_t reg_base, uint32_t *regs_off, int count, bool secure_write)
+{
+	int i;
+
+	for (i = 0; i < count; i++, regs_off += 2) {
+		uint32_t reg_addr = reg_base + regs_off[0];
+		uint32_t reg_val = regs_off[1];
+
+		if (secure_write) {
+			struct tmel_secure_io nss_noc = {0};
+			int error;
+
+			/*
+			 * Write the value into the registers
+			 * using secure IO.
+			 */
+			nss_noc.reg_addr = reg_addr;
+			nss_noc.reg_val = reg_val;
+			error = tmelcom_secure_io_write(&nss_noc, sizeof(struct tmel_secure_io));
+			if (error) {
+				pr_err("Failed to configure NSS NOC reg = 0x%x, val=0x%x\n", reg_addr, reg_val);
+				return error;
+			}
+		} else {
+			void __iomem *map_addr;
+
+			/*
+			 * Write the value into the registers
+			 * using regular IO mapping.
+			 */
+			map_addr = ioremap(reg_addr, sizeof(uint32_t));
+			if (!map_addr) {
+				pr_err("Failed to configure NSS NOC reg = 0x%x, val=0x%x\n", reg_addr, reg_val);
+				return -EINVAL;
+			}
+
+			writel(reg_val, map_addr);
+			iounmap(map_addr);
+		}
+
+		pr_debug("Configuring nss_noc for addr: (0x%x), val: (0x%x)\n", reg_addr, reg_val);
+	}
+
+	return 0;
+}
+
+/*
+ * nss_noc_reg_update - Update NSS NOC register settings
+ * @pdev: Pointer to the platform device structure
+ *
+ * This function updates the NSS NoC Register addresses by writing
+ * the values to the respective registers.
+ *
+ * Return: 0 on success, negative error code on failure.
+ */
+static inline int nss_noc_reg_update(struct platform_device *pdev)
+{
+	int ret, count;
+	struct device_node *np = (&pdev->dev)->of_node;
+	struct device_node *child = NULL;
+	bool secure_write = false;
+	uint32_t *regs_off = NULL;
+	uint32_t reg_base;
+
+	for_each_available_child_of_node(np, child) {
+		/*
+		 * Only read the registers if the corresponding (nss-noc)
+		 * property is defined in the DTSI.
+		 * Else, bypass the IO write operations.
+		 */
+		if (of_property_match_string(child, "prop-name", "nss_noc") < 0)
+			continue;
+
+		secure_write = of_property_read_bool(child, "secure-write");
+
+		/*
+		 * Read the Register base address from the DTSI.
+		 */
+		ret = of_property_read_u32(child, "reg-base", &reg_base);
+		if (ret) {
+			pr_err("%px: Failed to read the Register base address\n", child);
+			return ret;
+		}
+
+		/*
+		 * Read the number of register elements.
+		 */
+		count = of_property_count_u32_elems(child, "reg-offset");
+		if ((count == 0) || (count % 2)) {
+			pr_err("%px: Invalid entries obtained from the DTSI\n", child);
+			return -EINVAL;
+		}
+
+		/*
+		 * Allocate memory for reading NOC register
+		 * values from DTSI.
+		 */
+		regs_off = vmalloc(sizeof(u32) * count);
+		if (!regs_off) {
+			pr_err("%px: Failed to allocate memory for reading NOC regs\n", child);
+			return -EINVAL;
+		}
+
+		/*
+		 * Read the register offsets and their values
+		 * from the DTSI and write into address.
+		 */
+		ret = of_property_read_u32_array(child, "reg-offset", regs_off, count);
+		if (ret) {
+			pr_err("%px: Error in fetching the offset address and value for Register\n", child);
+			goto fail;
+		}
+
+		ret = nss_noc_reg_write(reg_base, regs_off, count/2, secure_write);
+		if (ret)
+			goto fail;
+
+		vfree(regs_off);
+		return 0;
+fail:
+		vfree(regs_off);
+		return ret;
+	}
+
+	return 0;
+}
+#endif
 
 /*
  * nss_dp_hal_clock_set_and_enable()
@@ -64,6 +229,96 @@ int32_t nss_dp_hal_clock_set_and_enable(struct device *dev, const char *id, unsi
 		return -1;
 	}
 
+	return 0;
+}
+
+#ifdef CONFIG_IO_COHERENCY
+/*
+ * nss_dp_hal_configure_llc()
+ *	Writes into the EDMA Descriptor rings cache registers.
+ */
+static int nss_dp_hal_configure_llc(struct edma_gbl_ctx *egc, struct device_node *np)
+{
+	int ring_idx, count, ret;
+
+	/*
+	 * Read the number of elements.
+	 */
+	count = of_property_count_u32_elems(np, "cache_val");
+	if (!count) {
+		pr_err("%px: Invalid entries obtained from the DTSI\n", np);
+		return -EINVAL;
+	}
+
+	/*
+	 * Allocate memory for reading cache
+	 * register data from DTSI.
+	 */
+	egc->cache_data = vmalloc(sizeof(u32) * count);
+	if (!egc->cache_data) {
+		pr_err("%px: Failed to allocate memory for reading cache register data\n", np);
+		return -EINVAL;
+	}
+
+	/*
+	 * Read the cache register data
+	 * from the DTSI.
+	 */
+	ret = of_property_read_u32_array(np, "cache_val", egc->cache_data, count);
+	if (ret) {
+		pr_err("%px: Error in fetching the data for cache Registers\n", np);
+		goto fail;
+	}
+
+	/*
+	 * Write the data into cache registers
+	 */
+	for (ring_idx = 0; ring_idx < EDMA_MAX_RXDESC_RINGS; ring_idx++) {
+		edma_reg_write(EDMA_REG_RXDESC_CACHE(ring_idx), egc->cache_data[0]);
+	}
+
+	for (ring_idx = 0; ring_idx < EDMA_MAX_TXCMPL_RINGS; ring_idx++) {
+		edma_reg_write(EDMA_REG_TXCMPL_CACHE(ring_idx), egc->cache_data[1]);
+	}
+
+	edma_reg_write(EDMA_REG_CACHEINDEX_LUT, egc->cache_data[2]);
+	edma_reg_write(EDMA_REG_AXCACHE_OVERRIDE, egc->cache_data[3]);
+	edma_reg_write(EDMA_REG_AXIW_CTRL, egc->cache_data[4]);
+	vfree(egc->cache_data);
+	return 0;
+
+fail:
+	vfree(egc->cache_data);
+	return ret;
+}
+#endif
+
+/*
+ * nss_dp_hal_cache_info_setup()
+ *	Setup the Descriptor rings cache data
+ *	from the DTSI.
+ *
+ * Returns 0: success and a negative error code on failure.
+ */
+int nss_dp_hal_cache_info_setup(void *ctx)
+{
+	struct edma_gbl_ctx *egc = (struct edma_gbl_ctx *)ctx;
+	egc->cache_data = NULL;
+
+#ifdef CONFIG_IO_COHERENCY
+	struct platform_device *pdev = egc->pdev;
+	struct device_node *np = (&pdev->dev)->of_node;
+	struct device_node *child = NULL;
+
+	for_each_available_child_of_node(np, child) {
+		/*
+		 * Read the EDMA Descriptor rings cache register data
+		 * defined in the DTSI.
+		 */
+		if (!of_property_match_string(child, "prop-name", "llcc_cache"))
+			return nss_dp_hal_configure_llc(egc, child);
+	}
+#endif
 	return 0;
 }
 
@@ -170,6 +425,29 @@ int32_t nss_dp_hal_configure_clocks(void *ctx)
 		return -1;
 	}
 
+	err = nss_dp_hal_clock_set_and_enable(&pdev->dev, NSS_DP_EDMA_NSSNOC_MEMNOC_CLK,
+					NSS_DP_EDMA_NSSNOC_MEMNOC_CLK_FREQ);
+	if (err) {
+		return -1;
+	}
+
+	err = nss_dp_hal_clock_set_and_enable(&pdev->dev, NSS_DP_EDMA_NSSNOC_MEM_NOC_1_CLK,
+					NSS_DP_EDMA_NSSNOC_MEM_NOC_1_CLK_FREQ);
+	if (err) {
+		return -1;
+	}
+
+#ifdef CONFIG_IO_COHERENCY
+	/*
+	 * TODO: Get rid of the above compile time MACRO and
+	 * invoke the reg_update API based on the global flag
+	 * from the DTSI.
+	 */
+	err = nss_noc_reg_update(pdev);
+        if (err) {
+                return -1;
+        }
+#endif
 	return 0;
 }
 
@@ -202,14 +480,14 @@ int32_t nss_dp_hal_hw_reset(void *ctx)
 	 *
 	 * TODO: Revisit if this global storage is actually required.
 	 */
-	edma_gbl_ctx.hw_rst = edma_hw_rst;
+	edma_gbl_ctx->hw_rst = edma_hw_rst;
 
 	/*
 	 * Store the obtained edma configuration reset handle (`edma_cfg_rst`) in the global context
 	 * (`edma_gbl_ctx`) for future use. This allows for centralized configuration reset control
 	 * throughout the driver.
 	 */
-	edma_gbl_ctx.cfg_rst = edma_cfg_rst;
+	edma_gbl_ctx->cfg_rst = edma_cfg_rst;
 
 	reset_control_assert(edma_hw_rst);
 	udelay(100);

--- a/hal/soc_ops/ipq54xx/nss_ipq54xx.h
+++ b/hal/soc_ops/ipq54xx/nss_ipq54xx.h
@@ -14,6 +14,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
+#include <asm/cacheflush.h>
+
 #ifndef __NSS_DP_ARCH_H__
 #define __NSS_DP_ARCH_H__
 
@@ -52,8 +54,9 @@
 /*
  * TX/RX NAPI budget
  */
-#define NSS_DP_HAL_RX_NAPI_BUDGET       256
+#define NSS_DP_HAL_RX_NAPI_BUDGET       128
 #define NSS_DP_HAL_TX_NAPI_BUDGET       256
+#define NSS_DP_HAL_RXFILL_NAPI_BUDGET	512
 
 /*
  * EDMA clock's
@@ -69,6 +72,8 @@
 #define NSS_DP_EDMA_NSSCFG_CLK			"nss-nsscfg-clk"
 #define NSS_DP_EDMA_NSSNOC_ATB_CLK		"nss-nssnoc-atb-clk"
 #define NSS_DP_EDMA_NSSNOC_NSSCC_CLK		"nss-nssnoc-nsscc-clk"
+#define NSS_DP_EDMA_NSSNOC_MEMNOC_CLK		"nss-nssnoc-memnoc-clk"
+#define NSS_DP_EDMA_NSSNOC_MEM_NOC_1_CLK	"nss-nssnoc-mem-noc-1-clk"
 #define NSS_DP_EDMA_NSSNOC_PCNOC_1_CLK		"nss-nssnoc-pcnoc-1-clk"
 #define NSS_DP_EDMA_NSSNOC_QOSGEN_REF_CLK	"nss-nssnoc-qosgen-ref-clk"
 #define NSS_DP_EDMA_NSSNOC_SNOC_1_CLK		"nss-nssnoc-snoc-1-clk"
@@ -91,12 +96,37 @@
 #define NSS_DP_EDMA_NSSCFG_CLK_FREQ			100000000
 #define NSS_DP_EDMA_NSSNOC_ATB_CLK_FREQ			240000000
 #define NSS_DP_EDMA_NSSNOC_NSSCC_CLK_FREQ		100000000
+#define NSS_DP_EDMA_NSSNOC_MEMNOC_CLK_FREQ		375000000
+#define NSS_DP_EDMA_NSSNOC_MEM_NOC_1_CLK_FREQ		375000000
 #define NSS_DP_EDMA_NSSNOC_PCNOC_1_CLK_FREQ		100000000
 #define NSS_DP_EDMA_NSSNOC_QOSGEN_REF_CLK_FREQ		6000000
 #define NSS_DP_EDMA_NSSNOC_SNOC_1_CLK_FREQ		266666666
 #define NSS_DP_EDMA_NSSNOC_SNOC_CLK_FREQ		266666666
 #define NSS_DP_EDMA_NSSNOC_TIMEOUT_REF_CLK_FREQ		6000000
 #define NSS_DP_EDMA_NSSNOC_XO_DCD_CLK_FREQ		24000000
+
+/*
+ * Set the flag only for 64-bit DMA address.
+ */
+#ifdef CONFIG_ARCH_DMA_ADDR_T_64BIT
+#define NSS_DP_HIGHMEM_SUPP
+#endif
+
+#define EDMA_MAX_DMA_MASK_BIT_HI 40
+
+/*
+ * SoC specific RX ring max value
+ */
+#if defined (NSS_DP_VP_RINGS)
+#define NSS_DP_VP_NUM_RINGS 1
+#else
+#define NSS_DP_VP_NUM_RINGS 0
+#endif
+
+/*
+ * SoC specific RX ring max value
+ */
+#define EDMA_RX_DESC_RING_MAX (NR_CPUS + NSS_DP_VP_NUM_RINGS)
 
 /**
  * nss_dp_hal_gmac_stats
@@ -140,9 +170,38 @@ extern bool nss_dp_hal_nsm_sawf_sc_stats_read(struct nss_dp_hal_nsm_sawf_sc_stat
 extern int32_t nss_dp_hal_clock_set_and_enable(struct device *dev, const char *id, unsigned long rate);
 extern struct nss_dp_data_plane_ops nss_dp_edma_ops;
 extern int32_t nss_dp_hal_configure_clocks(void *ctx);
+extern int nss_dp_hal_cache_info_setup(void *ctx);
 extern int32_t nss_dp_hal_hw_reset(void *ctx);
 #ifdef NSS_DP_PPEDS_SUPPORT
 extern struct nss_dp_ppeds_ops edma_ppeds_ops;
 #endif
+
+static inline void edma_dmac_inv_range(const void *start, const void *end){
+
+#ifndef CONFIG_IO_COHERENCY
+	dmac_inv_range(start, end);
+#endif
+}
+
+static inline void edma_dmac_inv_range_no_dsb(const void *start, const void *end){
+
+#ifndef CONFIG_IO_COHERENCY
+	dmac_inv_range_no_dsb(start, end);
+#endif
+}
+
+static inline void edma_dmac_clean_range_no_dsb(const void *start, const void *end){
+
+#ifndef CONFIG_IO_COHERENCY
+	dmac_clean_range_no_dsb(start, end);
+#endif
+}
+
+static inline void edma_dsb(void){
+
+#ifndef CONFIG_IO_COHERENCY
+        dsb(st);
+#endif
+}
 
 #endif /* __NSS_DP_ARCH_H__ */

--- a/hal/soc_ops/ipq60xx/nss_ipq60xx.c
+++ b/hal/soc_ops/ipq60xx/nss_ipq60xx.c
@@ -30,6 +30,24 @@ bool nss_dp_hal_nsm_sawf_sc_stats_read(struct nss_dp_hal_nsm_sawf_sc_stats *nsm_
 }
 
 /*
+ * nss_dp_hal_deinit_soc_priv_flags()
+ *	API to de-initialize DP DEV flags field
+ */
+void nss_dp_hal_deinit_soc_priv_flags(struct nss_dp_dev *dp_priv)
+{
+	return;
+}
+
+/*
+ * nss_dp_hal_init_soc_priv_flags()
+ *	API to initialize DP DEV flags field
+ */
+void nss_dp_hal_init_soc_priv_flags(struct nss_dp_dev *dp_priv)
+{
+	return;
+}
+
+/*
  * nss_dp_hal_get_data_plane_ops()
  *	Return the data plane ops for registered data plane.
  */

--- a/hal/soc_ops/ipq60xx/nss_ipq60xx.h
+++ b/hal/soc_ops/ipq60xx/nss_ipq60xx.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020-2021, The Linux Foundation. All rights reserved.
  *
- * Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -40,6 +40,7 @@
  */
 #define NSS_DP_HAL_RX_NAPI_BUDGET	32
 #define NSS_DP_HAL_TX_NAPI_BUDGET	32
+#define NSS_DP_HAL_RXFILL_NAPI_BUDGET	0
 
 /**
  * nss_dp_hal_gmac_stats

--- a/hal/soc_ops/ipq807x/nss_ipq807x.c
+++ b/hal/soc_ops/ipq807x/nss_ipq807x.c
@@ -30,6 +30,24 @@ bool nss_dp_hal_nsm_sawf_sc_stats_read(struct nss_dp_hal_nsm_sawf_sc_stats *nsm_
 }
 
 /*
+ * nss_dp_hal_deinit_soc_priv_flags()
+ *	API to de-initialize DP DEV flags field
+ */
+void nss_dp_hal_deinit_soc_priv_flags(struct nss_dp_dev *dp_priv)
+{
+	return;
+}
+
+/*
+ * nss_dp_hal_init_soc_priv_flags()
+ *	API to initialize DP DEV flags field
+ */
+void nss_dp_hal_init_soc_priv_flags(struct nss_dp_dev *dp_priv)
+{
+	return;
+}
+
+/*
  * nss_dp_hal_get_data_plane_ops()
  *	Return the data plane ops for registered data plane.
  */

--- a/hal/soc_ops/ipq807x/nss_ipq807x.h
+++ b/hal/soc_ops/ipq807x/nss_ipq807x.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020-2021, The Linux Foundation. All rights reserved.
  *
- * Copyright (c) 2022-2023 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -40,6 +40,7 @@
  */
 #define NSS_DP_HAL_RX_NAPI_BUDGET	32
 #define NSS_DP_HAL_TX_NAPI_BUDGET	32
+#define NSS_DP_HAL_RXFILL_NAPI_BUDGET	0
 
 /**
  * nss_dp_hal_gmac_stats

--- a/hal/soc_ops/ipq95xx/nss_ipq95xx.c
+++ b/hal/soc_ops/ipq95xx/nss_ipq95xx.c
@@ -33,6 +33,24 @@ bool nss_dp_hal_nsm_sawf_sc_stats_read(struct nss_dp_hal_nsm_sawf_sc_stats *nsm_
 }
 
 /*
+ * nss_dp_hal_deinit_soc_priv_flags()
+ *	API to de-initialize DP DEV flags field
+ */
+void nss_dp_hal_deinit_soc_priv_flags(struct nss_dp_dev *dp_priv)
+{
+	return;
+}
+
+/*
+ * nss_dp_hal_init_soc_priv_flags()
+ *	API to initialize DP DEV flags field
+ */
+void nss_dp_hal_init_soc_priv_flags(struct nss_dp_dev *dp_priv)
+{
+	return;
+}
+
+/*
  * nss_dp_hal_get_data_plane_ops()
  *	Return the data plane ops for registered data plane.
  */
@@ -67,6 +85,19 @@ int32_t nss_dp_hal_clock_set_and_enable(struct device *dev, const char *id, unsi
 		return -1;
 	}
 
+	return 0;
+}
+
+/*
+ * nss_dp_hal_cache_info_setup()
+ *	Dummy wrap-around function.
+ *	Returns 0: success
+ */
+int nss_dp_hal_cache_info_setup(void *ctx)
+{
+	struct edma_gbl_ctx *egc = (struct edma_gbl_ctx *)ctx;
+
+	egc->cache_data = NULL;
 	return 0;
 }
 
@@ -224,7 +255,7 @@ int32_t nss_dp_hal_hw_reset(void *ctx)
  	 *
  	 * TODO: Revisit if this global storage is actually required.
  	 */
-	edma_gbl_ctx.hw_rst = edma_hw_rst;
+	edma_gbl_ctx->hw_rst = edma_hw_rst;
 
 	reset_control_assert(edma_hw_rst);
 	udelay(100);

--- a/hal/soc_ops/ipq95xx/nss_ipq95xx.h
+++ b/hal/soc_ops/ipq95xx/nss_ipq95xx.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2021, The Linux Foundation. All rights reserved.
  *
- * Copyright (c) 2022-2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) 2022-2025 Qualcomm Innovation Center, Inc. All rights reserved.
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -15,6 +15,8 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
+
+#include <asm/cacheflush.h>
 
 #ifndef __NSS_DP_ARCH_H__
 #define __NSS_DP_ARCH_H__
@@ -48,6 +50,7 @@
  */
 #define NSS_DP_HAL_RX_NAPI_BUDGET	128
 #define NSS_DP_HAL_TX_NAPI_BUDGET	512
+#define NSS_DP_HAL_RXFILL_NAPI_BUDGET	512
 
 /*
  * Timestamp information for the latency measurement
@@ -107,6 +110,22 @@
 #define NSS_DP_EDMA_NSSNOC_MEM_NOC_1_CLK_FREQ		533333333
 #define NSS_DP_EDMA_NSSNOC_MEMNOC_CLK_FREQ		533333333
 
+#define EDMA_MAX_DMA_MASK_BIT_HI 32
+
+/*
+ * SoC specific RX ring max value
+ */
+#if defined (NSS_DP_VP_RINGS)
+#define NSS_DP_VP_NUM_RINGS 1
+#else
+#define NSS_DP_VP_NUM_RINGS 0
+#endif
+
+/*
+ * SoC specific RX ring max value
+ */
+#define EDMA_RX_DESC_RING_MAX (NR_CPUS + NSS_DP_VP_NUM_RINGS)
+
 /**
  * nss_dp_hal_gmac_stats
  *	The per-GMAC statistics structure.
@@ -149,9 +168,30 @@ extern bool nss_dp_hal_nsm_sawf_sc_stats_read(struct nss_dp_hal_nsm_sawf_sc_stat
 extern int32_t nss_dp_hal_clock_set_and_enable(struct device *dev, const char *id, unsigned long rate);
 extern struct nss_dp_data_plane_ops nss_dp_edma_ops;
 extern int32_t nss_dp_hal_configure_clocks(void *ctx);
+extern int nss_dp_hal_cache_info_setup(void *ctx);
 extern int32_t nss_dp_hal_hw_reset(void *ctx);
 #ifdef NSS_DP_PPEDS_SUPPORT
 extern struct nss_dp_ppeds_ops edma_ppeds_ops;
 #endif
+
+static inline void edma_dmac_inv_range(const void *start, const void *end){
+
+        dmac_inv_range(start, end);
+}
+
+static inline void edma_dmac_inv_range_no_dsb(const void *start, const void *end){
+
+        dmac_inv_range_no_dsb(start, end);
+}
+
+static inline void edma_dmac_clean_range_no_dsb(const void *start, const void *end){
+
+        dmac_clean_range_no_dsb(start, end);
+}
+
+static inline void edma_dsb(void){
+
+        dsb(st);
+}
 
 #endif /* __NSS_DP_ARCH_H__ */

--- a/include/nss_dp_dev.h
+++ b/include/nss_dp_dev.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016-2021, The Linux Foundation. All rights reserved.
  *
- * Copyright (c) 2021-2024, Qualcomm Innovation Center, Inc. All rights reserved
+ * Copyright (c) 2021-2025, Qualcomm Innovation Center, Inc. All rights reserved
  *
  * Permission to use, copy, modify, and/or distribute this software for
  * any purpose with or without fee is hereby granted, provided that the
@@ -28,6 +28,10 @@
 #include <linux/switch.h>
 #include <linux/version.h>
 #include <linux/ethtool.h>
+
+#ifdef CONFIG_QCA_MINIDUMP
+#include <soc/qcom/ctx-save.h>
+#endif
 
 #include "nss_dp_api_if.h"
 #include "nss_dp_hal_if.h"
@@ -112,7 +116,7 @@
 #define NSS_DP_VP_MAC_ID		(NSS_DP_HAL_MAX_PORTS + 2)
 #endif
 
-#if defined(NSS_DP_NETSTANDBY) && defined(NSS_DP_IPQ53XX)
+#if defined(NSS_DP_NETSTANDBY) && (defined(NSS_DP_IPQ53XX) || defined(NSS_DP_IPQ54XX))
 #define NSS_DP_EDMA_SWITCH_MHT_DEV_ID	1
 #endif
 
@@ -248,6 +252,9 @@ struct nss_dp_dev {
 	struct nss_dp_hal_info dp_info;
 					/* SoC specific data plane information */
 
+	struct nss_dp_vlan_append_info vlan_info;
+					/* VLAN header insertion details */
+
 	/* switchdev related attributes */
 #ifdef CONFIG_NET_SWITCHDEV
 	u8 stp_state;			/* STP state of this physical port */
@@ -280,7 +287,6 @@ struct nss_dp_global_ctx {
 #if defined(NSS_DP_EDMA_LOOPBACK_SUPPORT)
 	uint32_t edma_loopback_ring_size;	/* Loopback ring size */
 	uint32_t edma_loopback_buffer_size;	/* Loopback ring size */
-	bool edma_disable_loopback;		/* Disable loopback ring configuration */
 #endif
 	bool overwrite_mode;		/* Overwrite mode for Rx processing */
 	bool page_mode;			/* Page mode for Rx processing */
@@ -298,6 +304,11 @@ extern struct nss_dp_global_ctx dp_global_ctx;
 extern struct nss_dp_data_plane_ctx dp_global_data_plane_ctx[NSS_DP_MAX_PORTS];
 extern int nss_dp_rx_napi_budget;
 extern int nss_dp_tx_napi_budget;
+extern int nss_dp_rxfill_napi_budget;
+
+#if defined(NSS_DP_EDMA_LOOPBACK_SUPPORT)
+extern uint32_t edma_loopback_feature_type;
+#endif
 
 #if defined(NSS_DP_EDMA_V2)
 extern int nss_dp_rx_fc_xon;
@@ -331,6 +342,7 @@ enum nss_dp_state {
 	__NSS_DP_RXCSUM,	/* Rx checksum enabled			*/
 	__NSS_DP_AUTONEG,	/* Autonegotiation Enabled		*/
 	__NSS_DP_LINKPOLL,	/* Poll link status			*/
+	__NSS_DP_NO_LIST,	/* Deliver the packet directly to the Kernel stack without list based packet processing	*/
 };
 
 /*
@@ -381,5 +393,27 @@ static inline uint32_t nss_dp_get_idx_from_macid(uint32_t macid)
 	return (macid - 1);
 }
 #endif
+
+/*
+ * nss_dp_minidump_log()
+ *	To log data structures into minidump output
+ */
+static inline void nss_dp_minidump_log(void *start_addr, uint64_t size, const char *name) {
+#ifdef CONFIG_QCA_MINIDUMP
+	if (minidump_add_segments((uint64_t)(uintptr_t)(start_addr), size, QCA_WDT_LOG_DUMP_TYPE_MOD, name, MINIDUMP_CRASH_TYPE_NSS, "qca_nss_dp") != 0)
+		pr_warn("minidump_log failed for structure type %s at address %p\n", name, start_addr);
+#endif
+}
+
+/*
+ * nss_dp_minidump_free()
+ *	To unregister data structures from minidump tlv
+ */
+static inline void nss_dp_minidump_free(void *start_addr, const char *name) {
+#ifdef CONFIG_QCA_MINIDUMP
+	if (minidump_remove_segments((uint64_t)(uintptr_t)(start_addr)) != 0)
+		pr_warn("minidump_free failed for structure %s at address %p\n", name, start_addr);
+#endif
+}
 
 #endif	/* __NSS_DP_DEV_H__ */

--- a/nss_dp_attach.c
+++ b/nss_dp_attach.c
@@ -87,9 +87,9 @@ int nss_dp_override_data_plane(struct net_device *netdev,
 
 	if (!dp_ops->open || !dp_ops->close || !dp_ops->link_state
 		|| !dp_ops->mac_addr || !dp_ops->change_mtu || !dp_ops->xmit
-		|| !dp_ops->set_features || !dp_ops->pause_on_off || !dp_ops->deinit) {
+		|| !dp_ops->set_features || !dp_ops->pause_on_off || !dp_ops->init || !dp_ops->deinit) {
 		netdev_dbg(netdev, "All the op functions must be present, reject this registeration\n");
-		return NSS_DP_FAILURE;
+		return -EINVAL;
 	}
 
 	/*
@@ -129,7 +129,7 @@ int nss_dp_override_data_plane(struct net_device *netdev,
 	}
 	dp_dev->drv_flags |= NSS_DP_PRIV_FLAG(INIT_DONE);
 
-	return NSS_DP_SUCCESS;
+	return 0;
 }
 EXPORT_SYMBOL(nss_dp_override_data_plane);
 

--- a/nss_dp_main.c
+++ b/nss_dp_main.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016-2021, The Linux Foundation. All rights reserved.
  *
- * Copyright (c) 2021-2024, Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) 2021-2025, Qualcomm Innovation Center, Inc. All rights reserved.
  *
  * Permission to use, copy, modify, and/or distribute this software for
  * any purpose with or without fee is hereby granted, provided that the
@@ -43,7 +43,6 @@
 #include "nss_dp_hal.h"
 
 #define JUMBO_MRU_3K 3072
-#define NSS_DP_CAPWAP_VP_RX_CORE_INVALID 0XFFFF
 
 /* ipq40xx_mdio_data */
 struct ipq40xx_mdio_data {
@@ -73,13 +72,13 @@ int tx_requeue_stop = 1;
 module_param(tx_requeue_stop, int, 0640);
 MODULE_PARM_DESC(tx_requeue_stop, "disable tx requeue function");
 
-uint32_t nss_dp_capwap_vp_rx_core = NSS_DP_CAPWAP_VP_RX_CORE_INVALID;
-module_param(nss_dp_capwap_vp_rx_core, int, S_IRUGO);
-MODULE_PARM_DESC(nss_dp_capwap_vp_rx_core, "Capwap VP handling core");
-
 int nss_dp_rx_napi_budget = NSS_DP_HAL_RX_NAPI_BUDGET;
 module_param(nss_dp_rx_napi_budget, int, S_IRUGO);
 MODULE_PARM_DESC(nss_dp_rx_napi_budget, "Rx NAPI budget");
+
+int nss_dp_rxfill_napi_budget = NSS_DP_HAL_RXFILL_NAPI_BUDGET;
+module_param(nss_dp_rxfill_napi_budget, int, S_IRUGO);
+MODULE_PARM_DESC(nss_dp_rxfill_napi_budget, "Rx-fill NAPI budget");
 
 int nss_dp_tx_napi_budget = NSS_DP_HAL_TX_NAPI_BUDGET;
 module_param(nss_dp_tx_napi_budget, int, S_IRUGO);
@@ -156,9 +155,12 @@ int edma_loopback_buffer_size = EDMA_LOOPBACK_BUFFER_SIZE;
 module_param(edma_loopback_buffer_size, int, S_IRUGO);
 MODULE_PARM_DESC(edma_loopback_buffer_size, "Loopback buffer size");
 
-int edma_loopback_disable = 0;
-module_param(edma_loopback_disable, int, S_IRUGO);
-MODULE_PARM_DESC(edma_loopback_disable, "Loopback disable");
+/*
+ * Module parameter to enable / disable spectific loopback feature type
+ */
+uint32_t edma_loopback_feature_type = 1;
+module_param(edma_loopback_feature_type, int, 0644);
+MODULE_PARM_DESC(edma_loopback_feature_type, "loopback feature type 0x0: disabled, 0x1: default, 0x2: ddr extended buffer, 0x4: gretap to mapt");
 #endif
 
 /*
@@ -901,6 +903,8 @@ static int32_t nss_dp_probe(struct platform_device *pdev)
 	nss_dp_switchdev_setup(netdev);
 #endif
 
+	nss_dp_hal_init_soc_priv_flags(dp_priv);
+
 	ret = nss_dp_of_get_pdata(np, netdev, &gmac_hal_pdata);
 	if (ret != 0) {
 		goto fail;
@@ -1002,10 +1006,10 @@ static int32_t nss_dp_probe(struct platform_device *pdev)
 		phys_addr_t sec_addr = NSS_DP_GMAC_TS_ADDR_SEC(netdev->base_addr);
 		phys_addr_t nsec_addr = NSS_DP_GMAC_TS_ADDR_NSEC(netdev->base_addr);
 
-		edma_gbl_ctx.tstamp_sec = ioremap_nocache(sec_addr, sizeof(uint32_t));
-		edma_gbl_ctx.tstamp_nsec = ioremap_nocache(nsec_addr, sizeof(uint32_t));
+		edma_gbl_ctx->tstamp_sec = ioremap_nocache(sec_addr, sizeof(uint32_t));
+		edma_gbl_ctx->tstamp_nsec = ioremap_nocache(nsec_addr, sizeof(uint32_t));
 
-		if (unlikely(!edma_gbl_ctx.tstamp_sec || !edma_gbl_ctx.tstamp_nsec)) {
+		if (unlikely(!edma_gbl_ctx->tstamp_sec || !edma_gbl_ctx->tstamp_nsec)) {
 			pr_err("Unable to map the timestamp registers, sec addr:0x%llx,"
 					" nsec addr: 0x%llx\n", sec_addr, nsec_addr);
 			return 0;
@@ -1067,6 +1071,8 @@ static int nss_dp_remove(struct platform_device *pdev)
 #ifdef CONFIG_NET_SWITCHDEV
 		nss_dp_switchdev_cleanup(dp_priv->netdev);
 #endif
+
+		nss_dp_hal_deinit_soc_priv_flags(dp_priv);
 
 		/*
 		 * Execution of unregister_netdev may access statistics of the
@@ -1187,17 +1193,8 @@ static int __init nss_dp_init(void)
 	dp_global_ctx.rx_buf_size = NSS_DP_RX_BUFFER_SIZE;
 
 #if defined(NSS_DP_EDMA_LOOPBACK_SUPPORT)
-	if (edma_loopback_ring_size) {
-		dp_global_ctx.edma_loopback_ring_size = edma_loopback_ring_size;
-	}
-
-	if (edma_loopback_buffer_size) {
-		dp_global_ctx.edma_loopback_buffer_size = edma_loopback_buffer_size;
-	}
-
-	if (edma_loopback_disable) {
-		dp_global_ctx.edma_disable_loopback = edma_loopback_disable;
-	}
+	dp_global_ctx.edma_loopback_ring_size = edma_loopback_ring_size;
+	dp_global_ctx.edma_loopback_buffer_size = edma_loopback_buffer_size;
 #endif
 
 	/*

--- a/nss_dp_netstandby.c
+++ b/nss_dp_netstandby.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2016-2021, The Linux Foundation. All rights reserved.
  *
- * Copyright (c) 2021-2023, Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) 2021-2025, Qualcomm Innovation Center, Inc. All rights reserved.
  *
  * Permission to use, copy, modify, and/or distribute this software for
  * any purpose with or without fee is hereby granted, provided that the
@@ -30,6 +30,33 @@
 
 struct nss_dp_netstandby_gbl_ctx standby_gbl_ctx;
 
+#if defined(NSS_DP_IPQ53XX) || defined(NSS_DP_IPQ54XX)
+/*
+ * nss_dp_netstandby_is_switch_connected()
+ *	Check if switch is connected
+ */
+bool nss_dp_netstandby_is_switch_connected(struct nss_dp_netstandby_gbl_ctx *gbl_ctx)
+{
+	struct nss_dp_global_ctx *ctx = gbl_ctx->ctx;
+	struct nss_dp_dev *dp_priv;
+	int i = 0;
+
+	for (i = 0; i < NSS_DP_MAX_PORTS; i++) {
+		dp_priv = ctx->nss_dp[i];
+		if (!dp_priv) {
+			pr_warn("%p Error in retrieving netdev for ethernet port %d\n", ctx, i);
+			continue;
+		}
+
+		if (dp_priv->is_switch_connected)
+			return true;
+	}
+
+
+	return false;
+}
+#endif
+
 /*
  * nss_dp_netstandby_exit_standby()
  *	Exit standby API()
@@ -45,12 +72,17 @@ int nss_dp_netstandby_exit_standby(void *app_data, struct netstandby_exit_info *
 		return -ENOTSUPP;
 	}
 
-#if defined(NSS_DP_IPQ53XX)
+#if defined(NSS_DP_IPQ53XX) || defined(NSS_DP_IPQ54XX)
+	if (!nss_dp_netstandby_is_switch_connected(gbl_ctx))
+		goto exit_completion;
+
 	sw_err = fal_erp_standby_exit(DP_STANDBY_SWITCH_MHT_DEV_ID);
 	if (sw_err != SW_OK) {
 		pr_warn("Error in bringing MHT device out of power state\n");
 		return -ENOTSUPP;
 	}
+
+exit_completion:
 #endif
 
 	/*
@@ -79,7 +111,7 @@ int nss_dp_netstandby_enter_standby(void *app_data, struct netstandby_entry_info
 	struct net_device *dev;
 	int32_t mac_id = 0;
 	uint32_t port_active_bmap = 0;
-#if defined(NSS_DP_IPQ53XX)
+#if defined(NSS_DP_IPQ53XX) || defined(NSS_DP_IPQ54XX)
 	uint32_t port_mht_active_bmap = 0;
 	bool all_mht_down = false;
 	int index;
@@ -108,7 +140,7 @@ int nss_dp_netstandby_enter_standby(void *app_data, struct netstandby_entry_info
 			for (j = 0; j < entry_info->iface_cnt; j++) {
 				if (entry_info->dev[j] == dev) {
 					mac_id = ctx->nss_dp[i]->macid;
-#if defined(NSS_DP_IPQ53XX)
+#if defined(NSS_DP_IPQ53XX) || defined(NSS_DP_IPQ54XX)
 					index = nss_dp_get_idx_from_macid(mac_id);
 					if (ctx->nss_dp[index]->is_switch_connected) {
 						break;
@@ -128,7 +160,10 @@ int nss_dp_netstandby_enter_standby(void *app_data, struct netstandby_entry_info
 		return -ENOTSUPP;
 	}
 
-#if defined(NSS_DP_IPQ53XX)
+#if defined(NSS_DP_IPQ53XX) || defined(NSS_DP_IPQ54XX)
+	if (!nss_dp_netstandby_is_switch_connected(gbl_ctx))
+		goto enter_completion;
+
 	if (entry_info->nss_info.port_id > NSS_DP_HAL_MHT_SWT_MAX_PORTS) {
 		pr_warn("%p Port_id out of range(%d)\n", ctx, entry_info->nss_info.port_id);
 		fal_erp_standby_exit(DP_STANDBY_SWITCH_DEV_ID);
@@ -156,6 +191,7 @@ int nss_dp_netstandby_enter_standby(void *app_data, struct netstandby_entry_info
 			return -EINVAL;
 		}
 	}
+enter_completion:
 #endif
 
 	/*
@@ -180,7 +216,7 @@ bool nss_dp_get_eth_info(struct nss_dp_eth_netdev_info ethinfo[], uint8_t array_
 	struct nss_dp_global_ctx *dp_global = &dp_global_ctx;
 	struct nss_dp_dev *dp_priv;
 	uint8_t i  = 0;
-#if defined(NSS_DP_IPQ53XX)
+#if defined(NSS_DP_IPQ53XX) || defined(NSS_DP_IPQ54XX)
 	int port_id = 0;
 	sw_error_t ret;
 	a_bool_t status;
@@ -198,7 +234,7 @@ bool nss_dp_get_eth_info(struct nss_dp_eth_netdev_info ethinfo[], uint8_t array_
 		}
 
 		ethinfo[i].netdev = dp_priv->netdev;
-#if defined(NSS_DP_IPQ53XX)
+#if defined(NSS_DP_IPQ53XX) || defined(NSS_DP_IPQ54XX)
 		if (dp_global->nss_dp[i]->is_switch_connected) {
 			ethinfo[i].switch_connected = true;
 			for (port_id = 1; port_id <= MAX_MHT_PORTS ; port_id++) {

--- a/nss_dp_vp_main.c
+++ b/nss_dp_vp_main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024 Qualcomm Innovation Center, Inc. All rights reserved.
+ * Copyright (c) 2022, 2024-2025 Qualcomm Innovation Center, Inc. All rights reserved.
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -32,9 +32,6 @@
 
 extern struct net_device_ops nss_dp_netdev_ops;
 nss_dp_vp_rx_cb_t nss_dp_vp_rx_reg_cb = NULL;
-nss_dp_vp_list_rx_cb_t nss_dp_vp_list_rx_reg_cb = NULL;
-
-struct nss_dp_vp_skb_list gvp_skb_list[PPE_DRV_VIRTUAL_MAX];
 
 /*
  * nss_dp_vp_xmit()
@@ -57,11 +54,9 @@ EXPORT_SYMBOL(nss_dp_vp_xmit);
  * nss_dp_vp_rx_register_cb()
  *	Register VP callback
  */
-bool nss_dp_vp_rx_register_cb(nss_dp_vp_rx_cb_t cb, \
-		nss_dp_vp_list_rx_cb_t list_cb)
+bool nss_dp_vp_rx_register_cb(nss_dp_vp_rx_cb_t cb)
 {
 	rcu_assign_pointer(nss_dp_vp_rx_reg_cb, cb);
-	rcu_assign_pointer(nss_dp_vp_list_rx_reg_cb, list_cb);
 	synchronize_rcu();
 	return true;
 }
@@ -74,7 +69,6 @@ EXPORT_SYMBOL(nss_dp_vp_rx_register_cb);
 void nss_dp_vp_rx_unregister_cb(void)
 {
 	rcu_assign_pointer(nss_dp_vp_rx_reg_cb, NULL);
-	rcu_assign_pointer(nss_dp_vp_list_rx_reg_cb, NULL);
 	synchronize_rcu();
 }
 EXPORT_SYMBOL(nss_dp_vp_rx_unregister_cb);


### PR DESCRIPTION
Files modified:
```
modified:   Makefile
modified:   exports/nss_dp_api_if.h
modified:   exports/nss_dp_vp.h
modified:   hal/include/nss_dp_hal.h
modified:   hal/soc_ops/ipq50xx/nss_ipq50xx.c
modified:   hal/soc_ops/ipq50xx/nss_ipq50xx.h
modified:   hal/soc_ops/ipq53xx/nss_ipq53xx.c
modified:   hal/soc_ops/ipq53xx/nss_ipq53xx.h
modified:   hal/soc_ops/ipq54xx/nss_ipq54xx.c
modified:   hal/soc_ops/ipq54xx/nss_ipq54xx.h
modified:   hal/soc_ops/ipq60xx/nss_ipq60xx.c
modified:   hal/soc_ops/ipq60xx/nss_ipq60xx.h
modified:   hal/soc_ops/ipq807x/nss_ipq807x.c
modified:   hal/soc_ops/ipq807x/nss_ipq807x.h
modified:   hal/soc_ops/ipq95xx/nss_ipq95xx.c
modified:   hal/soc_ops/ipq95xx/nss_ipq95xx.h
modified:   include/nss_dp_dev.h
modified:   nss_dp_attach.c
modified:   nss_dp_main.c
modified:   nss_dp_netstandby.c
modified:   nss_dp_vp_main.c
```
Commits:
```
2025-12-26  c8d2c85  [qca-nss-dp] edma_v2: Check for null dp_ops->init()
2025-12-26  ca6fe81  [qca-nss-dp] edma_v2: Initialize pcpu_stats and stats before usage
2025-12-26  262ba4a  [qca-nss-dp] edma_v2: Check correct pointer
2025-10-14  16978c7  [qca-nss-dp] Fix memory allocation
2025-10-07  964e985  [qca-nss-dp] Fix Queue to word mapping for EDMA RxDesc rings.
2025-10-07  550e9fc  [qca-nss-dp] Fix Queue to word mapping for EDMA PPE-DS rings.
2025-10-07  77d4558  [qca-nss-dp] Fix Queue to word mapping for EDMA loopback rings.
2025-09-18  4f7173f  [qca-nss-dp] Allocate tmp_arr size considering 32 bits element size
2025-08-07  7a08130  [qca-nss-dp] Bug fixes for ppe_vp list path
2024-12-03  dfdffb7  [qca-nss-dp] Add support for new ring and queues
2025-08-05  cf1737f  [qca-nss-dp] Fix nss_dp_vp_skb_list len type from uint16_t to uint32_t
2025-03-25  f927004  [qca-nss-dp] Use egress_dev txdesc_ring in ppe-vp active mode
2025-07-28  595933d  [qca-nss-dp] Fix the skb ip summed value for scatter frames
2025-06-24  c087c22  [qca-nss-dp] Set Atheros header for MHT switch based on DTSI.
2025-05-14  57c9c1e  [qca-nss-dp] Decouple flow index check from HOST QDISC check
2025-04-25  9ec92fe  [qca-nss-dp] Added sysfs utility for crash trigger from module
2025-04-10  943ceae  [qca-nss-dp] Added minidump support for global data structure
2025-03-25  71a70bc  [qca-nss-dp] Enabling Hairpin NATv6 with EDMA loopback ring
2024-12-10  fc4a1b3  [qca-nss-dp] loopback ring feature initialization
2025-04-09  4dd003c  [qca-nss-dp]: export EDMA MHT tx ring fc_group info debugfs for DSA work with MHT HOLB
2025-03-24  d21b3a5  [qca-nss-dp] Fix to Disable EDMA RxDesc Ring Interrupt Mask
2025-04-11  c5d0453  [qca-nss-dp] fix loopback ring memory allocation.
2025-01-06  be4adc6  [qca-nss-dp]: Correct the SAWF metadata parsing in EDMA descriptor for PPE VP mode.
2025-03-06  486c21a  [qca-nss-dp] Fix the BUG_ON crash during EDMA bootup
2025-01-02  6a179f0  [netstandby] Call MHT enter and exit api only when MHT switch is connected
2025-01-29  84950c1  [qca-nss-dp] Add support to Configure EDMA based on DDR size
2025-01-29  7704371  [qca-nss-dp] Disable flow cookie infrastructure in Marina SoC
2025-01-20  3e8f4e2  [qca-nss-dp] Handle VP rx packets with fake_mac header set in Rx desc
2025-01-23  04b3b98  [qca-nss-dp] Adding a prefetch for skb shared info
2025-01-10  3144cf9  [qca-nss-dp] Enable PPE-DS rings in EDMA to support 40-bit addressing
2025-01-13  84c7d51  [qca-nss-dp] Enable PTP on medium profile
2024-12-11  4b85e9f  [qca-nss-dp] Add memnoc and memnoc_1 clocks initialization for Marina
2024-12-12  0c7a552  [qca-nss-dp] Fix free of ring descriptors when CONFIG_IO_COHERENCY is enabled
2024-12-11  62aef6a  [qca-nss-dp] Skip filling service classid in skb mark for PPE_VP path.
2024-12-10  d0922d9  [qca-nss-dp]: Enable print when wrong MTU is configured
2024-12-03  af4c256  [qca-nss-dp] Fix for VLAN TAG Info for LM Profiles.
2024-07-09  c43efd0  [qca-nss-dp] Enable low threshold interrupts for Rx-fill rings
2024-11-27  498c613  [qca-nss-dp] Fix loopback ring issue on ipq54xx
2024-11-14  0f0f029  [qca-nss-dp] Enable llcc cachablility support
2024-11-25  d58313e  [qca-nss-dp] Make the PPE-DS Rxfill/Txcmpl rings cacheable
2024-11-25  939a5b5  [qca-nss-dp] Rx reap single loop optimization for Marina
2024-09-23  5a292cd  [qca-nss-dp] Rx NAPI Budget Change
2024-11-21  7a6511f  [qca-nss-dp] Fix the max number of edma interrupts
2024-10-28  d52c0cc  [qca-nss-dp] Prefetch Tx complete descriptor
2024-10-28  9c0bd74  [qca-nss-dp]  Prefetch Tx descriptor
2024-11-16  3a28a75  [qca-nss-dp] Changes to read the vlan append info for the feature enabled ports.
2024-11-21  29f5110  [qca-nss-dp] Fix loopback ring config for ipq54xx
2024-10-28  8d88042  [qca-nss-dp] Prefetch Rxfill descriptor
2024-10-28  f5f86c1  [qca-nss-dp] Enable ring reset for IPQ54XX
2024-09-26  41486fd  [qca_nss_dp]: Introducing Cache Maintenance Function Wrappers for each SOC.
2024-11-07  6429d1c  [qca-nss-dp] Add ipq54xx specific changes for loopback ring
2024-11-07  2eaca60  [qca-nss-dp] Change to break dependency for rxfill intr
2024-10-19  a01f30e  [qca-nss-dp] Enable IO Coherency in Marina
2024-11-04  ba9316f  [qca-nss-dp] Enable parsing of MHT ports for Marina in netstandby.
2024-09-12  edde5a4  [qca_nss_dp]: Making RxFILL_Desc Cacheable with IO Coherency
2024-10-30  0a7805e  [qca-nss-dp] Set skb int_pri from rx descriptor
2024-10-29  09ebef3  [qca-nss-dp] Print the edma tx logs before clearing the error bits.
2024-10-28  34c8e73  [qca-nss-dp] Increase EDMA loopback buffer array index to 16
2024-08-29  4932c2c  [qca-nss-dp] Move pr_info to pr_debug
```

I did not include the changes to edma_v2 below:
```
modified:   hal/dp_ops/edma_dp/edma_v2/edma.c
modified:   hal/dp_ops/edma_dp/edma_v2/edma.h
modified:   hal/dp_ops/edma_dp/edma_v2/edma_cfg_rx.c
modified:   hal/dp_ops/edma_dp/edma_v2/edma_cfg_rx.h
modified:   hal/dp_ops/edma_dp/edma_v2/edma_cfg_rx_loopback.c
modified:   hal/dp_ops/edma_dp/edma_v2/edma_cfg_tx.c
modified:   hal/dp_ops/edma_dp/edma_v2/edma_cfg_tx_loopback.c
modified:   hal/dp_ops/edma_dp/edma_v2/edma_debugfs.c
modified:   hal/dp_ops/edma_dp/edma_v2/edma_dp.c
modified:   hal/dp_ops/edma_dp/edma_v2/edma_dp_vp.c
modified:   hal/dp_ops/edma_dp/edma_v2/edma_misc.c
modified:   hal/dp_ops/edma_dp/edma_v2/edma_ppeds.c
modified:   hal/dp_ops/edma_dp/edma_v2/edma_procfs.c
modified:   hal/dp_ops/edma_dp/edma_v2/edma_regs.h
modified:   hal/dp_ops/edma_dp/edma_v2/edma_rx.c
modified:   hal/dp_ops/edma_dp/edma_v2/edma_rx.h
modified:   hal/dp_ops/edma_dp/edma_v2/edma_tx.c
modified:   hal/dp_ops/edma_dp/edma_v2/edma_tx.h
```
Signed-off-by: Kristian Skramstad <kristian+github@83.no>